### PR TITLE
Base64 implementation using Bouncycastle

### DIFF
--- a/src/main/java/org/projectodd/nodej/crypto/Hash.java
+++ b/src/main/java/org/projectodd/nodej/crypto/Hash.java
@@ -50,11 +50,15 @@ public class Hash {
     private static String formatter(String algorithm) {
         return algorithm.toLowerCase().replaceFirst("sha", "$0-");
     }
-    
+
     private static Encoder encoderFor(String nodeName) {
-        switch(nodeName) {
-        case "binary": return Encoder.RAW;
-        case "hex": return Encoder.HEX;
+        switch (nodeName) {
+            case "binary":
+                return Encoder.RAW;
+            case "hex":
+                return Encoder.HEX;
+            case "base64":
+                return Encoder.BASE64;
         }
         return Encoder.RAW;
     }

--- a/src/main/java/org/projectodd/nodej/crypto/encoders/Base64.java
+++ b/src/main/java/org/projectodd/nodej/crypto/encoders/Base64.java
@@ -1,0 +1,277 @@
+package org.projectodd.nodej.crypto.encoders;
+
+/*
+ * Taken with small modifications
+ *
+ * Copyright (c) 2000-2011 The Legion Of The Bouncy Castle (http://www.bouncycastle.org)
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class Base64 implements Encoder {
+
+    private final byte[] encodingTable = {
+            (byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F', (byte) 'G',
+            (byte) 'H', (byte) 'I', (byte) 'J', (byte) 'K', (byte) 'L', (byte) 'M', (byte) 'N',
+            (byte) 'O', (byte) 'P', (byte) 'Q', (byte) 'R', (byte) 'S', (byte) 'T', (byte) 'U',
+            (byte) 'V', (byte) 'W', (byte) 'X', (byte) 'Y', (byte) 'Z',
+            (byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd', (byte) 'e', (byte) 'f', (byte) 'g',
+            (byte) 'h', (byte) 'i', (byte) 'j', (byte) 'k', (byte) 'l', (byte) 'm', (byte) 'n',
+            (byte) 'o', (byte) 'p', (byte) 'q', (byte) 'r', (byte) 's', (byte) 't', (byte) 'u',
+            (byte) 'v',
+            (byte) 'w', (byte) 'x', (byte) 'y', (byte) 'z',
+            (byte) '0', (byte) '1', (byte) '2', (byte) '3', (byte) '4', (byte) '5', (byte) '6',
+            (byte) '7', (byte) '8', (byte) '9',
+            (byte) '+', (byte) '/'
+    };
+
+    private final byte padding = (byte) '=';
+
+    /*
+     * set up the decoding table.
+     */
+    private final byte[] decodingTable = new byte[128];
+
+    public Base64() {
+        initialiseDecodingTable();
+    }
+
+    /**
+     * encode the input data producing a base 64 encoded byte array.
+     *
+     * @return a byte array containing the base 64 encoded data.
+     */
+    @Override
+    public String encode(byte[] data) {
+
+        int len = (data.length + 2) / 3 * 4;
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream(len);
+
+        try {
+            encode(data, 0, data.length, bOut);
+        } catch (Exception e) {
+            throw new RuntimeException("exception encoding base64 string: " + e.getMessage(), e);
+        }
+
+        return new String(bOut.toByteArray());
+    }
+
+    /**
+     * decode the base 64 encoded String data - whitespace will be ignored.
+     *
+     * @return a byte array representing the decoded data.
+     */
+    @Override
+    public byte[] decode(String data) {
+        int len = data.length() / 4 * 3;
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream(len);
+
+        try {
+            decode(data, bOut);
+        } catch (Exception e) {
+            throw new RuntimeException("unable to decode base64 string: " + e.getMessage(), e);
+        }
+
+        return bOut.toByteArray();
+    }
+
+    private void initialiseDecodingTable() {
+        for (int i = 0; i < decodingTable.length; i++) {
+            decodingTable[i] = (byte) 0xff;
+        }
+
+        for (int i = 0; i < encodingTable.length; i++) {
+            decodingTable[encodingTable[i]] = (byte) i;
+        }
+    }
+
+    /**
+     * encode the input data producing a base 64 output stream.
+     *
+     * @return the number of bytes produced.
+     */
+    private int encode(byte[] data, int off, int length, OutputStream out) throws IOException {
+        int modulus = length % 3;
+        int dataLength = (length - modulus);
+        int a1, a2, a3;
+
+        for (int i = off; i < off + dataLength; i += 3) {
+            a1 = data[i] & 0xff;
+            a2 = data[i + 1] & 0xff;
+            a3 = data[i + 2] & 0xff;
+
+            out.write(encodingTable[(a1 >>> 2) & 0x3f]);
+            out.write(encodingTable[((a1 << 4) | (a2 >>> 4)) & 0x3f]);
+            out.write(encodingTable[((a2 << 2) | (a3 >>> 6)) & 0x3f]);
+            out.write(encodingTable[a3 & 0x3f]);
+        }
+
+        /*
+         * process the tail end.
+         */
+        int b1, b2, b3;
+        int d1, d2;
+
+        switch (modulus) {
+            case 0:        /* nothing left to do */
+                break;
+            case 1:
+                d1 = data[off + dataLength] & 0xff;
+                b1 = (d1 >>> 2) & 0x3f;
+                b2 = (d1 << 4) & 0x3f;
+
+                out.write(encodingTable[b1]);
+                out.write(encodingTable[b2]);
+                out.write(padding);
+                out.write(padding);
+                break;
+            case 2:
+                d1 = data[off + dataLength] & 0xff;
+                d2 = data[off + dataLength + 1] & 0xff;
+
+                b1 = (d1 >>> 2) & 0x3f;
+                b2 = ((d1 << 4) | (d2 >>> 4)) & 0x3f;
+                b3 = (d2 << 2) & 0x3f;
+
+                out.write(encodingTable[b1]);
+                out.write(encodingTable[b2]);
+                out.write(encodingTable[b3]);
+                out.write(padding);
+                break;
+        }
+
+        return (dataLength / 3) * 4 + ((modulus == 0) ? 0 : 4);
+    }
+
+    private boolean ignore(char c) {
+        return (c == '\n' || c == '\r' || c == '\t' || c == ' ');
+    }
+
+    /**
+     * decode the base 64 encoded String data writing it to the given output stream,
+     * whitespace characters will be ignored.
+     *
+     * @return the number of bytes produced.
+     */
+    private int decode(String data, OutputStream out) throws IOException {
+        byte b1, b2, b3, b4;
+        int length = 0;
+
+        int end = data.length();
+
+        while (end > 0) {
+            if (!ignore(data.charAt(end - 1))) {
+                break;
+            }
+
+            end--;
+        }
+
+        int i = 0;
+        int finish = end - 4;
+
+        i = nextI(data, i, finish);
+
+        while (i < finish) {
+            b1 = decodingTable[data.charAt(i++)];
+
+            i = nextI(data, i, finish);
+
+            b2 = decodingTable[data.charAt(i++)];
+
+            i = nextI(data, i, finish);
+
+            b3 = decodingTable[data.charAt(i++)];
+
+            i = nextI(data, i, finish);
+
+            b4 = decodingTable[data.charAt(i++)];
+
+            if ((b1 | b2 | b3 | b4) < 0) {
+                throw new IOException("invalid characters encountered in base64 data");
+            }
+
+            out.write((b1 << 2) | (b2 >> 4));
+            out.write((b2 << 4) | (b3 >> 2));
+            out.write((b3 << 6) | b4);
+
+            length += 3;
+
+            i = nextI(data, i, finish);
+        }
+
+        length += decodeLastBlock(out, data.charAt(end - 4), data.charAt(end - 3), data.charAt(end - 2), data.charAt(end - 1));
+
+        return length;
+    }
+
+    private int decodeLastBlock(OutputStream out, char c1, char c2, char c3, char c4) throws IOException {
+        byte b1, b2, b3, b4;
+
+        if (c3 == padding) {
+            b1 = decodingTable[c1];
+            b2 = decodingTable[c2];
+
+            if ((b1 | b2) < 0) {
+                throw new IOException("invalid characters encountered at end of base64 data");
+            }
+
+            out.write((b1 << 2) | (b2 >> 4));
+
+            return 1;
+        } else if (c4 == padding) {
+            b1 = decodingTable[c1];
+            b2 = decodingTable[c2];
+            b3 = decodingTable[c3];
+
+            if ((b1 | b2 | b3) < 0) {
+                throw new IOException("invalid characters encountered at end of base64 data");
+            }
+
+            out.write((b1 << 2) | (b2 >> 4));
+            out.write((b2 << 4) | (b3 >> 2));
+
+            return 2;
+        } else {
+            b1 = decodingTable[c1];
+            b2 = decodingTable[c2];
+            b3 = decodingTable[c3];
+            b4 = decodingTable[c4];
+
+            if ((b1 | b2 | b3 | b4) < 0) {
+                throw new IOException("invalid characters encountered at end of base64 data");
+            }
+
+            out.write((b1 << 2) | (b2 >> 4));
+            out.write((b2 << 4) | (b3 >> 2));
+            out.write((b3 << 6) | b4);
+
+            return 3;
+        }
+    }
+
+    private int nextI(String data, int i, int finish) {
+        while ((i < finish) && ignore(data.charAt(i))) {
+            i++;
+        }
+        return i;
+    }
+
+}

--- a/src/main/java/org/projectodd/nodej/crypto/encoders/Encoder.java
+++ b/src/main/java/org/projectodd/nodej/crypto/encoders/Encoder.java
@@ -8,6 +8,7 @@ public interface Encoder {
 
     public static final Hex HEX = new Hex();
     public static final Raw RAW = new Raw();
+    public static final Base64 BASE64 = new Base64();
 
     public byte[] decode(String data);
 

--- a/src/main/java/org/projectodd/nodej/crypto/encoders/Hex.java
+++ b/src/main/java/org/projectodd/nodej/crypto/encoders/Hex.java
@@ -1,4 +1,6 @@
 /*
+ * Taken with small modifications
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/org/projectodd/nodej/crypto/encoders/StringUtils.java
+++ b/src/main/java/org/projectodd/nodej/crypto/encoders/StringUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.projectodd.nodej.crypto.encoders;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+/**
+ * Converts String to and from bytes using the encodings required by the Java specification. These encodings are
+ * specified in <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">
+ * Standard charsets</a>.
+ * <p/>
+ * <p>This class is immutable and thread-safe.</p>
+ *
+ * @version $Id$
+ * @see CharEncoding
+ * @see <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
+ * @since 1.4
+ */
+public class StringUtils {
+
+    public static final Charset US_ASCII = Charset.forName("US-ASCII");
+
+    /**
+     * Encodes the given string into a sequence of bytes using the US-ASCII charset, storing the result into a new byte
+     * array.
+     *
+     * @param string the String to encode, may be {@code null}
+     * @return encoded bytes, or {@code null} if the input string was {@code null}
+     * @throws NullPointerException Thrown if {@link Charsets#US_ASCII} is not initialized, which should never happen since it is
+     *                              required by the Java platform specification.
+     * @see <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
+     * @see #getBytesUnchecked(String, String)
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     */
+    public static byte[] getBytesUsAscii(final String string) {
+        return string == null ? null : string.getBytes(US_ASCII);
+    }
+
+    /**
+     * Constructs a new <code>String</code> by decoding the specified array of bytes using the US-ASCII charset.
+     *
+     * @param bytes The bytes to be decoded into characters
+     * @return A new <code>String</code> decoded from the specified array of bytes using the US-ASCII charset,
+     *         or {@code null} if the input byte array was {@code null}.
+     * @throws NullPointerException Thrown if {@link Charsets#US_ASCII} is not initialized, which should never happen since it is
+     *                              required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     */
+    public static String newStringUsAscii(final byte[] bytes) {
+        return new String(bytes, US_ASCII);
+    }
+
+}

--- a/src/test/resources/crypto/crypto_test.js
+++ b/src/test/resources/crypto/crypto_test.js
@@ -10,19 +10,19 @@ function testCreateHash() {
   vassert.testComplete();
 }
 
+function testMD5HashDigest() {
+    var hash = crypto.createHash('md5');
+    hash.update('Now is the winter of our discontent ');
+    hash.update('made glorious summer');
+    vassert.assertEquals('74402c8710d5107209ee554e2e11bcf7', hash.digest('hex'));
+    vassert.testComplete();
+}
+
 function testSHA1HashDigest() {
   var hash = crypto.createHash('sha1');
   hash.update('Now is the winter of our discontent ');
   hash.update('made glorious summer');
   vassert.assertEquals('2365c163a22c69f11c2394ee6064fcfec1d19284', hash.digest('hex'));
-  vassert.testComplete();
-}
-
-function testMD5HashDigest() {
-  var hash = crypto.createHash('md5');
-  hash.update('Now is the winter of our discontent ');
-  hash.update('made glorious summer');
-  vassert.assertEquals('74402c8710d5107209ee554e2e11bcf7', hash.digest('hex'));
   vassert.testComplete();
 }
 
@@ -40,6 +40,38 @@ function testSHA512HashDigest() {
   hash.update('made glorious summer');
   vassert.assertEquals('e62168d80ddc7d992053122b166de7d8db0112422baf4b1255b7421789fd595a3be341c2740153579456fdecf8264a7fc2a0c7aa6851ae531b36ebe94ad16b61', hash.digest('hex'));
   vassert.testComplete();
+}
+
+function testBase64MD5HashDigest() {
+    var hash = crypto.createHash('md5');
+    hash.update('Now is the winter of our discontent ');
+    hash.update('made glorious summer');
+    vassert.assertEquals('dEAshxDVEHIJ7lVOLhG89w==', hash.digest('base64'));
+    vassert.testComplete();
+}
+
+function testSHA1HashDigest() {
+    var hash = crypto.createHash('sha1');
+    hash.update('Now is the winter of our discontent ');
+    hash.update('made glorious summer');
+    vassert.assertEquals('I2XBY6IsafEcI5TuYGT8/sHRkoQ=', hash.digest('base64'));
+    vassert.testComplete();
+}
+
+function testBase64SHA256HashDigest() {
+    var hash = crypto.createHash('sha256');
+    hash.update('Now is the winter of our discontent ');
+    hash.update('made glorious summer');
+    vassert.assertEquals('RToH6LcSTgyxNrfvg45t14suSUTw5VRrgC3mt3S+wug=', hash.digest('base64'));
+    vassert.testComplete();
+}
+
+function testBase64SHA512HashDigest() {
+    var hash = crypto.createHash('sha512');
+    hash.update('Now is the winter of our discontent ');
+    hash.update('made glorious summer');
+    vassert.assertEquals('5iFo2A3cfZkgUxIrFm3n2NsBEkIrr0sSVbdCF4n9WVo740HCdAFTV5RW/ez4Jkp/wqDHqmhRrlMbNuvpStFrYQ==', hash.digest('base64'));
+    vassert.testComplete();
 }
 
 initTests(this);


### PR DESCRIPTION
:tada: 

Hi my friend, commons-code was too verbose and over-engineered, so the best alternative was to extract the encoder from Bouncycastle, props ( http://www.bouncycastle.org/licence.html) already added. 

If we opt in favor of bouncycastle as a crypto lib, in the future will be possible to remove the encoders. For now, I'll try to keep it simple.
