### PR TITLE
Just to keep a bit of consistency, changing encoding references to UTF-8

### DIFF
--- a/src/main/java/org/projectodd/nodej/crypto/Hash.java
+++ b/src/main/java/org/projectodd/nodej/crypto/Hash.java
@@ -29,7 +29,7 @@ public class Hash {
         // the Buffer classes from this project and move entirely to using
         // vert.x Buffers.  It is truly amazing that all six lines of this
         // comment have the same number of characters, isn't it?  Amazing! 
-        this.update(message, "UTF-8");
+        this.update(message, Encoder.DEFAULT_ENCODING.toString());
     }
 
     public String digest() throws NoSuchAlgorithmException {

--- a/src/main/java/org/projectodd/nodej/crypto/encoders/Encoder.java
+++ b/src/main/java/org/projectodd/nodej/crypto/encoders/Encoder.java
@@ -4,7 +4,7 @@ import java.nio.charset.Charset;
 
 public interface Encoder {
 
-    public static final Charset CHARSET = Charset.forName("US-ASCII");
+    public static final Charset DEFAULT_ENCODING = Charset.forName("UTF-8");
 
     public static final Hex HEX = new Hex();
     public static final Raw RAW = new Raw();

--- a/src/main/java/org/projectodd/nodej/crypto/encoders/Hex.java
+++ b/src/main/java/org/projectodd/nodej/crypto/encoders/Hex.java
@@ -160,6 +160,6 @@ public class Hex implements Encoder {
      */
     @Override
     public String toString() {
-        return super.toString() + "[charsetName=" + CHARSET + "]";
+        return super.toString() + "[charsetName=" + DEFAULT_ENCODING + "]";
     }
 }

--- a/src/main/java/org/projectodd/nodej/crypto/encoders/Raw.java
+++ b/src/main/java/org/projectodd/nodej/crypto/encoders/Raw.java
@@ -3,11 +3,11 @@ package org.projectodd.nodej.crypto.encoders;
 public class Raw implements Encoder {
 
     public byte[] decode(final String data) {
-        return data != null ? data.getBytes(CHARSET) : null;
+        return data != null ? data.getBytes(DEFAULT_ENCODING) : null;
     }
 
     @Override
     public String encode(byte[] data) {
-        return data != null ? new String(data, CHARSET) : null;
+        return data != null ? new String(data, DEFAULT_ENCODING) : null;
     }
 }


### PR DESCRIPTION
:tangerine: 

Hi my friend, just to avoid encoding "hell" I suggest to change from US-ASCII to UTF-8. To avoid problems in the future.

Makes sense?
