### PR TITLE
Bump to vertx 2.1M4-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <version.junit>4.7</version.junit>
     <!-- TODO: Remove the netty dependency (QueryString) -->
     <version.netty>3.6.1.Final</version.netty>
-    <version.vertx>2.1M3-SNAPSHOT</version.vertx>
+    <version.vertx>2.1M4-SNAPSHOT</version.vertx>
     <version.testtools>2.0.2-final</version.testtools>
     <version.lang-js.verticle>1.0.0-SNAPSHOT</version.lang-js.verticle>
     <version.dynjs.verticle>1.0.0-SNAPSHOT</version.dynjs.verticle>


### PR DESCRIPTION
2.1M3-SNAPSHOT is gone from maven-snapshot, update to the latest one.
Fixes the following `mvn install` error:

```
[ERROR] Failed to execute goal on project nodyn-verticle: Could not
resolve dependencies for project
org.projectodd:nodyn-verticle:jar:0.1.1-SNAPSHOT: The following
artifacts could not be resolved:
io.vertx:vertx-core:jar:2.1M3-SNAPSHOT,
io.vertx:vertx-platform:jar:2.1M3-SNAPSHOT: Could not find artifact
io.vertx:vertx-core:jar:2.1M3-SNAPSHOT in projectodd-snapshot
(https://repository-projectodd.forge.cloudbees.com/snapshot) ->
[Help 1]
```
