### PR TITLE
Remove sigs from shaded files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,16 @@
                   <mainClass>org.projectodd.nodyn.Main</mainClass>
                 </transformer>
               </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                   <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
To avoid SecurityException when starting the jar file, no signature files should be included
in META-INF
