### PR TITLE
Exclude signatures from external jars on shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,16 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <artifactSet>
                 <excludes>
                   <exclude>io.nodyn:jvm-npm</exclude>


### PR DESCRIPTION
To reproduce the issue just run _bin/nodyn_
