### PR TITLE
A few fix plus missing 'constants' core module

### DIFF
--- a/src/main/javascript/_http_client.js
+++ b/src/main/javascript/_http_client.js
@@ -56,7 +56,6 @@ module.exports.ClientRequest = ClientRequest;
 
 var DefaultRequestOptions = {
   host:     'localhost',
-  hostname: 'localhost',
   method:   'GET',
   path:     '/',
   port:     80
@@ -76,14 +75,13 @@ var httpRequest = module.exports.request = function(options, callback) {
   }
 
   options.host     = options.host     || DefaultRequestOptions.host;
-  options.hostname = options.hostname || DefaultRequestOptions.hostname;
   options.port     = options.port     || DefaultRequestOptions.port;
   options.method   = options.method   || DefaultRequestOptions.method;
   options.path     = options.path     || DefaultRequestOptions.path;
 
   var proxy = process.context.createHttpClient()
                     .setPort(options.port)
-                    .setHost(options.hostname);
+                    .setHost(options.hostname || options.host); // Favor hostname as per Node doc, but fallback on host
 
   var clientRequest = null; // The node.js representation
 

--- a/src/main/javascript/buffer.js
+++ b/src/main/javascript/buffer.js
@@ -85,7 +85,7 @@ Object.defineProperty( Buffer.prototype, "length", {
 } );
 
 var bufferToString = function(enc,start,end) {
-  if (arguments.length == 0 ) {
+  if (arguments.length <= 1 && enc == null) {
     return this.delegate.toString('utf-8');
   }
 

--- a/src/main/javascript/constants.js
+++ b/src/main/javascript/constants.js
@@ -1,0 +1,22 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+module.exports = process.binding['constants'];


### PR DESCRIPTION
Made two fixes:

http.request ignores hostname specified through "hostname" option. Now hostname has priority over host, as per Node documentation.

bufferToString fails when encoding passed is undefined. On real NodeJS this works fine, and some popular NPM modules (request) were breaking in part because of this.

Also added the 'constants' module from Node's sources.
