### PR TITLE
Fix concurrency issues caused by JS callbacks running in different event loops

### DIFF
--- a/src/main/java/org/projectodd/nodyn/Main.java
+++ b/src/main/java/org/projectodd/nodyn/Main.java
@@ -19,8 +19,10 @@ import org.dynjs.cli.Arguments;
 import org.dynjs.runtime.DynJS;
 import org.dynjs.runtime.ExecutionContext;
 import org.dynjs.runtime.GlobalObject;
+import org.dynjs.runtime.Runner;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
+import org.vertx.java.core.Handler;
 import org.vertx.java.core.Vertx;
 import org.vertx.java.core.VertxFactory;
 
@@ -53,6 +55,16 @@ public class Main extends org.dynjs.cli.Main {
                 break;
             }
         }
+    }
+
+    @Override
+    protected void executeRunner(final Runner runner) {
+        vertx.runOnContext(new Handler<Void>() {
+            @Override
+            public void handle(Void event) {
+                runner.execute();
+            }
+        });
     }
 
     @Override

--- a/src/main/javascript/_http_client.js
+++ b/src/main/javascript/_http_client.js
@@ -13,6 +13,7 @@ function ClientRequest(proxy) {
   this.timeoutId       = undefined;
   this.timeoutMsec     = undefined;
   this.timeoutCallback = undefined;
+  this.ended           = false;
   // TODO: These methods are not available on a
   // vert.x HttpClientRequest...
   this.setNoDelay = function() {};
@@ -25,6 +26,9 @@ ClientRequest.prototype.write = function(chunk, encoding) {
 };
 
 ClientRequest.prototype.end = function(b) {
+  if (this.ended) return;
+  this.ended = true;
+
   if (b) {
     this.proxy.end(b);
   } else {
@@ -33,7 +37,7 @@ ClientRequest.prototype.end = function(b) {
 };
 
 ClientRequest.prototype.abort = function(b) {
-  this.proxy.end();
+  this.end();
 };
 
 ClientRequest.prototype.setTimeout = function(msec, callback) {


### PR DESCRIPTION
I had issues with a module using process.nextTick to defer some processing. It randomly failed because code protected by a run once flag ended up being called twice.

I did this quick test:

```
for (var i = 0; i < 10; ++i) {
  process.nextTick(function() {
    for (var i = 0; i < 1000; ++i) {
      console.log(i);
    }
  });
}
```

I ended up with stuff like this:

```
773
795
774
796
775
```

Clearly the same JS context is running in parallel in multiple threads, and that's Not a Good Thing :)

I've had a look at the code and the problem was because the JS code initially ran inside a thread that wasn't bound to a specific event loop. So everytime the runInContext method was called a potentially different event loop was used from the event loop group (on my setup there are 8 of those).

Indeed, if I wrap my previous test in a process.nextTick, everything suddenly worked fine (since the thread from where the subsequent nextTicks are called is bound to an event loop).

So I slightly changed how the Main class runs the JS code to have it execute inside a runInContext.

For it to work I had to make a small change in DynJS, otherwise I couldn't cleanly hook at the correct spot. The other pull request is here: https://github.com/dynjs/dynjs/pull/124

I also included a fix for tolerating multiple calls to end on a client request, to mimic Node's behavior.
