### PR TITLE
childProcessSpec.js test fails depending of location.

### DIFF
--- a/src/test/javascript/forked_socket_module.js
+++ b/src/test/javascript/forked_socket_module.js
@@ -7,7 +7,7 @@ process.on('message', function(m, connection) {
     result += data.toString();
   });
   connection.on( 'end', function() {
-    if ( result.indexOf( 'Set-Cookie') >= 0 ) {
+    if ( result.indexOf( 'Set-Cookie' ) >= 0 || result.indexOf( '302 Found' ) ) {
       process.exit( 42 );
     }
     process.exit( -1 );


### PR DESCRIPTION
Motivation:
When running the integration tests the childProcessSpec.js test, 'should
be able to send sockets to a child'. The error displayed is:
Failed
    Expected 255 to be 42.

This might be suprising to see '255' instead of -1, which is the value
passed to process.exit in
src/test/javascript/forked_socket_module.js:13. I think this is because
the exit code is an unsigned 8-bit value and in this case -1 is
converted to 255. But that is not the cause of the failure of the test.

The reason I believe is that I'm located in Sweden and accessing
www.google.com will produce a redirect for me. There is no support for
redirect as far as I can tell at the momement.

Modifications:
Added an additional of the result which currently checks for the
existence of a HTTP 'Set-Cookie' header. This addtional check just
checks for a redirect ('302 Found')
