### PR TITLE
Add `-s support/settings.xml` to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To build nodyn from source, check out the repo, and run `mvn install`.
 
     $ git clone https://github.com/nodyn/nodyn.git
     $ cd nodyn
-    $ mvn install
+    $ mvn install -s support/settings.xml
 
 ## Website
 


### PR DESCRIPTION
`mvn install` didn't work for me (see below), but everything worked as expected after adding `-s support/settings.xml`

```
‣ mvn install
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Nodyn 0.1.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[WARNING] The POM for org.projectodd.rephract:rephract:jar:1.x.incremental.87 is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.510 s
[INFO] Finished at: 2014-10-08T22:56:24-07:00
[INFO] Final Memory: 8M/19M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project nodyn: Could not resolve dependencies for project io.nodyn:nodyn:jar:0.1.1-SNAPSHOT: Failure to find org.projectodd.rephract:rephract:jar:1.x.incremental.87 in <snip work stuff> was cached in the local repository, resolution will not be reattempted until the update interval has elapsed or updates are forced -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```
